### PR TITLE
feat(#16): add rule builder UI to extension options page

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -166,3 +166,195 @@ main {
   background-color: #ccc;
   cursor: not-allowed;
 }
+
+/* Tab Bar */
+
+.tab-bar {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid #ddd;
+  padding: 0 30px;
+  background-color: #fff;
+}
+
+.tab-btn {
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.tab-btn:hover {
+  color: #333;
+}
+
+.tab-btn.active {
+  color: #333;
+  border-bottom-color: #ff7f00;
+}
+
+/* Tab Panels */
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+/* Rule Sections */
+
+.rule-section {
+  margin-bottom: 24px;
+}
+
+.rule-section h2 {
+  margin: 0 0 4px;
+  font-size: 18px;
+}
+
+.rule-subtext {
+  font-size: 13px;
+  color: #666;
+  margin: 0 0 16px;
+}
+
+/* Condition Groups */
+
+.condition-group {
+  border-left: 3px solid #ff7f00;
+  background: #fafafa;
+  border-radius: 0 6px 6px 0;
+  padding: 12px 16px;
+}
+
+.condition-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Condition Rows */
+
+.condition-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.field-select {
+  flex: 0 0 140px;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.operator-select {
+  flex: 0 0 120px;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.value-input {
+  flex: 1;
+  min-width: 80px;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.value-input.hidden {
+  display: none;
+}
+
+.remove-row-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #ddd;
+  background: #fff;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  color: #999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease, border-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.remove-row-btn:hover {
+  color: #dc3545;
+  border-color: #dc3545;
+}
+
+/* Add Row Button */
+
+.add-row-btn {
+  width: 100%;
+  padding: 6px;
+  border: 1px dashed #ccc;
+  border-radius: 4px;
+  background: transparent;
+  color: #999;
+  font-size: 13px;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.add-row-btn:hover {
+  color: #ff7f00;
+  border-color: #ff7f00;
+}
+
+/* Add Group Button */
+
+.add-group-btn {
+  width: 100%;
+  padding: 8px;
+  border: 1px dashed #ccc;
+  border-radius: 4px;
+  background: transparent;
+  color: #999;
+  font-size: 13px;
+  cursor: pointer;
+  margin-top: 12px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.add-group-btn:hover {
+  color: #ff7f00;
+  border-color: #ff7f00;
+}
+
+/* OR Separator */
+
+.or-separator {
+  text-align: center;
+  color: #999;
+  font-size: 12px;
+  text-transform: uppercase;
+  padding: 8px 0;
+  font-weight: 600;
+}
+
+/* Rule Status */
+
+.rule-status {
+  font-size: 13px;
+  color: #666;
+  margin-top: 12px;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,19 +11,60 @@
     <header>
       <h1>Settings</h1>
     </header>
+    <nav class="tab-bar">
+      <button class="tab-btn active" data-tab="vehicles">Vehicle Collection Logic</button>
+      <button class="tab-btn" data-tab="realestate">Real Estate Collection Logic</button>
+      <button class="tab-btn" data-tab="data">Data Management</button>
+    </nav>
     <main>
-      <section class="data-management">
-        <h2>Data Management</h2>
-        <div class="stats-summary">
-          <div class="stats-grid">
-            <span>Vehicles:</span><span id="stats-vehicles">--</span>
-            <span>Real Estate:</span><span id="stats-realestate">--</span>
-            <span>Total listings:</span><span id="stats-total">--</span>
-            <span>Price changes:</span><span id="stats-price-changes">--</span>
+      <div class="tab-panel active" id="tab-vehicles">
+        <section class="rule-section">
+          <h2>Scanning Logic</h2>
+          <p class="rule-subtext">Only listings matching these conditions will be scanned</p>
+          <div class="rule-groups" id="vehicle-scan-groups"></div>
+          <button class="add-group-btn" data-target="vehicle-scan-groups">+</button>
+          <p class="rule-status"><span id="vehicle-scan-total">--</span> listings &middot; 0 ignored by these conditions</p>
+        </section>
+        <section class="rule-section">
+          <h2>Export Logic</h2>
+          <p class="rule-subtext">Only listings matching these conditions will be exported</p>
+          <div class="rule-groups" id="vehicle-export-groups"></div>
+          <button class="add-group-btn" data-target="vehicle-export-groups">+</button>
+          <p class="rule-status">0 / <span id="vehicle-export-total">--</span> listings matching these conditions</p>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="tab-realestate">
+        <section class="rule-section">
+          <h2>Scanning Logic</h2>
+          <p class="rule-subtext">Only listings matching these conditions will be scanned</p>
+          <div class="rule-groups" id="realestate-scan-groups"></div>
+          <button class="add-group-btn" data-target="realestate-scan-groups">+</button>
+          <p class="rule-status"><span id="realestate-scan-total">--</span> listings &middot; 0 ignored by these conditions</p>
+        </section>
+        <section class="rule-section">
+          <h2>Export Logic</h2>
+          <p class="rule-subtext">Only listings matching these conditions will be exported</p>
+          <div class="rule-groups" id="realestate-export-groups"></div>
+          <button class="add-group-btn" data-target="realestate-export-groups">+</button>
+          <p class="rule-status">0 / <span id="realestate-export-total">--</span> listings matching these conditions</p>
+        </section>
+      </div>
+
+      <div class="tab-panel" id="tab-data">
+        <section class="data-management">
+          <h2>Data Management</h2>
+          <div class="stats-summary">
+            <div class="stats-grid">
+              <span>Vehicles:</span><span id="stats-vehicles">--</span>
+              <span>Real Estate:</span><span id="stats-realestate">--</span>
+              <span>Total listings:</span><span id="stats-total">--</span>
+              <span>Price changes:</span><span id="stats-price-changes">--</span>
+            </div>
           </div>
-        </div>
-        <button id="clear-db-btn" class="danger-btn">Clear All Data</button>
-      </section>
+          <button id="clear-db-btn" class="danger-btn">Clear All Data</button>
+        </section>
+      </div>
     </main>
   </div>
 
@@ -43,6 +84,15 @@
       </div>
     </div>
   </dialog>
+
+  <template id="condition-row-template">
+    <div class="condition-row">
+      <select class="field-select"></select>
+      <select class="operator-select"></select>
+      <input class="value-input" type="text" placeholder="Value">
+      <button class="remove-row-btn">&times;</button>
+    </div>
+  </template>
 
   <script src="options.js"></script>
 </body>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,23 +1,296 @@
 import type { CollectionStats } from "../background/db";
 import type { ClearDatabaseMessage, ExportCsvMessage } from "../shared/messages";
 
+// --- DOM helper ---
+
 function $<T extends HTMLElement>(selector: string): T {
   const el = document.querySelector<T>(selector);
   if (!el) throw new Error(`Element not found for selector: ${selector}`);
   return el;
 }
 
-document.addEventListener("DOMContentLoaded", async () => {
-  setupEventListeners();
-  await loadStats();
-});
+// --- Field & operator definitions ---
 
-function setupEventListeners() {
-  $("#clear-db-btn").addEventListener("click", openConfirmDialog);
-  $("#dialog-export").addEventListener("click", handleExport);
-  $("#dialog-confirm").addEventListener("click", handleClear);
-  $("#dialog-cancel").addEventListener("click", closeDialog);
+interface FieldDef {
+  label: string;
+  value: string;
+  type: "numeric" | "string";
 }
+
+interface RowPreset {
+  field: string;
+  operator: string;
+  value: string;
+}
+
+const NUMERIC_OPERATORS = ["is", "≤", "≥", "<", ">", "is specified"];
+const STRING_OPERATORS = ["is", "is not", "is specified"];
+
+const VEHICLE_FIELDS: FieldDef[] = [
+  { label: "Price", value: "currentPrice", type: "numeric" },
+  { label: "Ad Type", value: "adType", type: "string" },
+  { label: "Manufacturer", value: "manufacturer", type: "string" },
+  { label: "Model", value: "model", type: "string" },
+  { label: "Year", value: "year", type: "numeric" },
+  { label: "Engine Type", value: "engineType", type: "string" },
+  { label: "Gear Box", value: "gearBox", type: "string" },
+  { label: "Hand", value: "hand", type: "numeric" },
+  { label: "Km", value: "km", type: "numeric" },
+  { label: "Color", value: "color", type: "string" },
+];
+
+const REALESTATE_FIELDS: FieldDef[] = [
+  { label: "Price", value: "currentPrice", type: "numeric" },
+  { label: "Ad Type", value: "adType", type: "string" },
+  { label: "Property Type", value: "propertyType", type: "string" },
+  { label: "Rooms", value: "rooms", type: "numeric" },
+  { label: "Square Meters", value: "squareMeters", type: "numeric" },
+  { label: "Floor", value: "floor", type: "numeric" },
+  { label: "Total Floors", value: "totalFloors", type: "numeric" },
+  { label: "Condition", value: "condition", type: "string" },
+  { label: "City", value: "city", type: "string" },
+  { label: "Neighborhood", value: "neighborhood", type: "string" },
+];
+
+// --- Tab switching ---
+
+function setupTabs() {
+  const buttons = document.querySelectorAll<HTMLButtonElement>(".tab-btn");
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      buttons.forEach((b) => b.classList.remove("active"));
+      document
+        .querySelectorAll(".tab-panel")
+        .forEach((p) => p.classList.remove("active"));
+
+      btn.classList.add("active");
+      const tabId = btn.dataset["tab"];
+      if (tabId) {
+        $(`#tab-${tabId}`).classList.add("active");
+      }
+    });
+  });
+}
+
+// --- Condition row creation ---
+
+function getOperators(fieldType: "numeric" | "string"): string[] {
+  return fieldType === "numeric" ? NUMERIC_OPERATORS : STRING_OPERATORS;
+}
+
+function populateOperatorSelect(
+  operatorSelect: HTMLSelectElement,
+  fieldType: "numeric" | "string",
+  presetOperator?: string,
+) {
+  operatorSelect.innerHTML = "";
+  for (const op of getOperators(fieldType)) {
+    const option = document.createElement("option");
+    option.value = op;
+    option.textContent = op;
+    operatorSelect.appendChild(option);
+  }
+  if (presetOperator) {
+    operatorSelect.value = presetOperator;
+  }
+}
+
+function updateValueVisibility(row: HTMLElement) {
+  const operatorSelect = row.querySelector<HTMLSelectElement>(".operator-select");
+  const valueInput = row.querySelector<HTMLInputElement>(".value-input");
+  if (!operatorSelect || !valueInput) return;
+
+  if (operatorSelect.value === "is specified") {
+    valueInput.classList.add("hidden");
+  } else {
+    valueInput.classList.remove("hidden");
+  }
+}
+
+function createConditionRow(fields: FieldDef[], preset?: RowPreset): HTMLDivElement {
+  const template = $<HTMLTemplateElement>("#condition-row-template");
+  const clone = template.content.cloneNode(true) as DocumentFragment;
+  const row = clone.querySelector<HTMLDivElement>(".condition-row")!;
+
+  const fieldSelect = row.querySelector<HTMLSelectElement>(".field-select")!;
+  const operatorSelect = row.querySelector<HTMLSelectElement>(".operator-select")!;
+  const valueInput = row.querySelector<HTMLInputElement>(".value-input")!;
+
+  for (const field of fields) {
+    const option = document.createElement("option");
+    option.value = field.value;
+    option.textContent = field.label;
+    fieldSelect.appendChild(option);
+  }
+
+  if (preset?.field) {
+    fieldSelect.value = preset.field;
+  }
+
+  const selectedField = fields.find((f) => f.value === fieldSelect.value);
+  const fieldType = selectedField?.type ?? "string";
+  populateOperatorSelect(operatorSelect, fieldType, preset?.operator);
+
+  if (preset?.value !== undefined) {
+    valueInput.value = preset.value;
+  }
+
+  updateValueVisibility(row);
+
+  fieldSelect.addEventListener("change", () => {
+    const newField = fields.find((f) => f.value === fieldSelect.value);
+    const newType = newField?.type ?? "string";
+    populateOperatorSelect(operatorSelect, newType);
+    updateValueVisibility(row);
+  });
+
+  operatorSelect.addEventListener("change", () => {
+    updateValueVisibility(row);
+  });
+
+  return row;
+}
+
+// --- Condition group creation ---
+
+function createConditionGroup(fields: FieldDef[], presetRows?: RowPreset[]): HTMLDivElement {
+  const group = document.createElement("div");
+  group.className = "condition-group";
+
+  const rowsContainer = document.createElement("div");
+  rowsContainer.className = "condition-rows";
+
+  const rows = presetRows && presetRows.length > 0 ? presetRows : [undefined];
+  for (const preset of rows) {
+    rowsContainer.appendChild(createConditionRow(fields, preset));
+  }
+
+  group.appendChild(rowsContainer);
+
+  const addBtn = document.createElement("button");
+  addBtn.className = "add-row-btn";
+  addBtn.textContent = "+ Add condition";
+  addBtn.addEventListener("click", () => {
+    rowsContainer.appendChild(createConditionRow(fields));
+  });
+  group.appendChild(addBtn);
+
+  return group;
+}
+
+// --- Render groups into a container ---
+
+function renderGroups(
+  containerId: string,
+  fields: FieldDef[],
+  presetGroups: RowPreset[][],
+) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = "";
+
+  presetGroups.forEach((groupPresets, i) => {
+    if (i > 0) {
+      const sep = document.createElement("div");
+      sep.className = "or-separator";
+      sep.textContent = "or";
+      container.appendChild(sep);
+    }
+    container.appendChild(createConditionGroup(fields, groupPresets));
+  });
+}
+
+// --- Determine fields from container ID ---
+
+function getFieldsForContainer(containerId: string): FieldDef[] {
+  return containerId.startsWith("vehicle") ? VEHICLE_FIELDS : REALESTATE_FIELDS;
+}
+
+// --- Add Group button handlers ---
+
+function setupAddGroupButtons() {
+  document.querySelectorAll<HTMLButtonElement>(".add-group-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const targetId = btn.dataset["target"];
+      if (!targetId) return;
+
+      const container = document.getElementById(targetId);
+      if (!container) return;
+
+      const fields = getFieldsForContainer(targetId);
+
+      if (container.children.length > 0) {
+        const sep = document.createElement("div");
+        sep.className = "or-separator";
+        sep.textContent = "or";
+        container.appendChild(sep);
+      }
+
+      container.appendChild(createConditionGroup(fields));
+    });
+  });
+}
+
+// --- Remove row delegation ---
+
+function setupRemoveRowDelegation() {
+  $("main").addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+    if (!target.classList.contains("remove-row-btn")) return;
+
+    const row = target.closest(".condition-row");
+    if (!row) return;
+
+    const rowsContainer = row.closest(".condition-rows");
+    const group = row.closest(".condition-group");
+    if (!rowsContainer || !group) return;
+
+    row.remove();
+
+    if (rowsContainer.children.length === 0) {
+      const rulesContainer = group.parentElement;
+      if (!rulesContainer) return;
+
+      const groupIndex = Array.from(rulesContainer.children).indexOf(group);
+
+      // Remove adjacent OR separator
+      if (groupIndex > 0) {
+        const prev = rulesContainer.children[groupIndex - 1];
+        if (prev?.classList.contains("or-separator")) {
+          prev.remove();
+        }
+      } else if (rulesContainer.children.length > 1) {
+        const next = rulesContainer.children[groupIndex + 1];
+        if (next?.classList.contains("or-separator")) {
+          next.remove();
+        }
+      }
+
+      group.remove();
+    }
+  });
+}
+
+// --- Render sample data ---
+
+function renderSampleData() {
+  renderGroups("vehicle-scan-groups", VEHICLE_FIELDS, [
+    [
+      { field: "manufacturer", operator: "is", value: "" },
+      { field: "currentPrice", operator: "≤", value: "60000" },
+      { field: "currentPrice", operator: ">", value: "60000" },
+    ],
+    [{ field: "manufacturer", operator: "is", value: "Toyota" }],
+  ]);
+
+  renderGroups("vehicle-export-groups", VEHICLE_FIELDS, [
+    [{ field: "currentPrice", operator: "is specified", value: "" }],
+  ]);
+
+  // Real estate tabs start empty
+}
+
+// --- Stats ---
 
 async function loadStats(): Promise<CollectionStats | null> {
   try {
@@ -29,12 +302,20 @@ async function loadStats(): Promise<CollectionStats | null> {
     $("#stats-total").textContent = String(stats.total);
     $("#stats-price-changes").textContent = String(stats.priceChanges);
     $<HTMLButtonElement>("#clear-db-btn").disabled = stats.total === 0;
+
+    $("#vehicle-scan-total").textContent = String(stats.vehicles);
+    $("#vehicle-export-total").textContent = String(stats.vehicles);
+    $("#realestate-scan-total").textContent = String(stats.realestate);
+    $("#realestate-export-total").textContent = String(stats.realestate);
+
     return stats;
   } catch (error) {
     console.error("[yad2-collector] Failed to load stats:", error);
     return null;
   }
 }
+
+// --- Dialog handlers ---
 
 async function openConfirmDialog() {
   const stats = await loadStats();
@@ -98,3 +379,21 @@ async function handleClear() {
     setDialogButtons(false);
   }
 }
+
+function setupEventListeners() {
+  $("#clear-db-btn").addEventListener("click", openConfirmDialog);
+  $("#dialog-export").addEventListener("click", handleExport);
+  $("#dialog-confirm").addEventListener("click", handleClear);
+  $("#dialog-cancel").addEventListener("click", closeDialog);
+}
+
+// --- Init ---
+
+document.addEventListener("DOMContentLoaded", async () => {
+  setupTabs();
+  setupAddGroupButtons();
+  setupRemoveRowDelegation();
+  renderSampleData();
+  setupEventListeners();
+  await loadStats();
+});


### PR DESCRIPTION
## Summary
- Add tabbed interface to options page (Vehicle Collection Logic, Real Estate Collection Logic, Data Management)
- Build rule builder UI with condition groups (OR logic) and condition rows (AND logic) for scanning and export rules
- Support field/operator dropdowns with type-aware operators (numeric vs string), value inputs, and "is specified" hiding the value field
- Render hardcoded sample data on vehicle tab; real estate tab starts empty for user-driven creation
- Wire rule status lines to real IndexedDB listing counts

Closes #16

## Test plan
- [x] Open extension settings and verify three tabs switch correctly
- [x] Vehicle tab shows sample rules (manufacturer/price conditions across two OR groups)
- [x] Real estate tab starts empty; + buttons add groups and rows
- [x] Changing field dropdown updates available operators (numeric vs string)
- [x] Selecting "is specified" operator hides the value input
- [x] × button removes rows; removing last row removes the group and adjacent OR separator
- [x] "+ Add condition" inside a group appends a new row
- [x] "+" below groups adds a new OR group with separator
- [x] Status lines show real listing counts from IndexedDB
- [x] Data Management tab works unchanged (stats, clear, export)
- [x] `npm run lint` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)